### PR TITLE
Updated base image with build arg

### DIFF
--- a/java-8/Dockerfile
+++ b/java-8/Dockerfile
@@ -8,7 +8,14 @@ ENV TZ="Europe/Oslo"
 ENV DEFAULT_JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
 
 COPY ./run-java.sh /
-ONBUILD COPY target/*.jar /app/
+
+ONBUILD ARG JAR_FILE=*.jar
+ONBUILD COPY target/${JAR_FILE} /app/
+ONBUILD RUN if [ "${JAR_FILE}" != "*.jar" ]; \
+    then mv /app/${JAR_FILE} /app/app.jar; \
+  elif [ `ls *.jar 2>/dev/null | wc -l | tr -d '[[:space:]]'` -eq 1 ]; \
+    then mv /app/`ls *.jar` /app/app.jar; \
+  fi
 
 WORKDIR /app
 

--- a/java-8/README.md
+++ b/java-8/README.md
@@ -1,51 +1,31 @@
 NAIS Java 8 baseimage
 =====================
 
-WIP draft.
 
-
-Usage
+Basic Usage
 ---------------------
 
-Build your app to `./target/app.jar` or provide your own jar file 
-using the `JAR_FILE` environment variable.
+Create a `Dockerfile` containing:
 
-Make your app expose services on port 8080 as default.
-
-Include custom Java options in `$JAVA_OPTS`.
-
-By default, the base image will copy all JAR files in the `target/` directory. If there's exactly one JAR file present, 
-there's no need calling it `app.jar` or specifying the `JAR_FILE` env: the run script will use it as is.
-
-If, however, there are one or more JAR files present, one must either call the main JAR `app.jar` or specify `JAR_FILE`.
-
-Example
----------------------
-
-The `Dockerfile` below allows us to specify an alternate JAR file build time (via `--build-arg JAR_FILE=my.jar`) 
-and run time as an environment variable. We also specify additional options for the JVM:
-
-```
+```Dockerfile
 FROM navikt/java:8
-
-ARG JAR_FILE
-ENV JAR_FILE ${JAR_FILE}
-
-ENV JAVA_OPTS="-Djavax.net.ssl.trustStore=/truststore.jks \
-               -Djavax.net.ssl.trustStorePassword=changeit"
-
 ```
 
-The JAR file can be a bit simplified during build:
+By default JARs under `target/` is copied into the container; if there's exactly one JAR present it will be ran.
+Port `8080` is exposed by default, so you should make your app listen on this port.
+Custom runtime options may be specified using `$JAVA_OPTS`.
+
+### I have more than one JAR and get `Error: Unable to access jarfile app.jar`
+If there's more than one JAR in `target/`, you must specify which JAR to run using the `JAR_FILE` build arg or environment variable:
+
+Specify which JAR to copy and run during build time:
 
 ```
-ARG BUILD_NO
-ENV JAR_FILE ${JAR_FILE:-myapp-${BUILD_NO}.jar}
+docker build -t myimage:tag --build-arg JAR_FILE=my-app.jar .
 ```
 
-This will either use the environment variable `JAR_FILE` or fall back 
-to the default `myapp-BUILD_NO`, where `BUILD_NO` is specified build time:
+Or specifying which JAR to run at runtime:
 
 ```
-docker build -t myapp:latest --build-arg BUILD_NO=1337 .
+docker run -e JAR_FILE=my-app.jar myimage:tag
 ```

--- a/java-8/run-java.sh
+++ b/java-8/run-java.sh
@@ -1,22 +1,3 @@
 #!/usr/bin/env sh
 
-JAR_FILE=${JAR_FILE:-app.jar}
-
-if [ ! -f "${JAR_FILE}" ];
-then
-    nr_jars=`ls *.jar 2>/dev/null | wc -l | tr -d '[[:space:]]'`
-
-    if [ ${nr_jars} -gt 1 ];
-    then
-        echo "Have ${nr_jars} JARs to choose from. Specify which one using JAR_FILE environment variable,"
-        echo "or rename the correct one as app.jar"
-        exit 1
-    fi
-
-    if [ ${nr_jars} = 1 ];
-    then
-      JAR_FILE=`ls *.jar`
-    fi
-fi
-
 exec java ${DEFAULT_JAVA_OPTS} ${JAVA_OPTS} -jar ${JAR_FILE:-app.jar}


### PR DESCRIPTION
Simplifies startup script by adding build arg `JAR_FILE`.

If there's exactly one JAR under `target/` or `JAR_FILE` build arg is specified, it will be copied as `/app/app.jar` and will be ran.
If there's more than one, which JAR to run must be specified using `JAR_FILE` env var/build arg.

This pull should not break any previous usages.