### PR TITLE
Remove ONBUILD to simplify image

### DIFF
--- a/java-8/Dockerfile
+++ b/java-8/Dockerfile
@@ -9,14 +9,6 @@ ENV DEFAULT_JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimi
 
 COPY ./run-java.sh /
 
-ONBUILD ARG JAR_FILE=*.jar
-ONBUILD COPY target/${JAR_FILE} /app/
-ONBUILD RUN if [ "${JAR_FILE}" != "*.jar" ]; \
-    then mv /app/${JAR_FILE} /app/app.jar; \
-  elif [ `ls *.jar 2>/dev/null | wc -l | tr -d '[[:space:]]'` -eq 1 ]; \
-    then mv /app/`ls *.jar` /app/app.jar; \
-  fi
-
 WORKDIR /app
 
 EXPOSE 8080

--- a/java-8/run-java.sh
+++ b/java-8/run-java.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-exec java ${DEFAULT_JAVA_OPTS} ${JAVA_OPTS} -jar ${JAR_FILE:-app.jar}
+exec java ${DEFAULT_JAVA_OPTS} ${JAVA_OPTS} -jar app.jar


### PR DESCRIPTION
Per the discussion on Slack a while back, we should remove the `ONBUILD` stuff to reduce the complexity on the image.