### PR TITLE
Java8 init

### DIFF
--- a/java-8/Dockerfile
+++ b/java-8/Dockerfile
@@ -1,5 +1,8 @@
 FROM openjdk:8-jre-alpine
 
+RUN wget -O /dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64
+RUN chmod +x /dumb-init
+
 ENV LC_ALL="no_NB.UTF-8"
 ENV LANG="no_NB.UTF-8"
 ENV TZ="Europe/Oslo"
@@ -13,4 +16,5 @@ WORKDIR /app
 
 EXPOSE 8080
 
-ENTRYPOINT ["/run-java.sh"]
+ENTRYPOINT ["/dumb-init"]
+CMD ["/run-java.sh"]

--- a/java-8/Dockerfile
+++ b/java-8/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:8-jdk-alpine
 
 RUN wget -O /dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64
 RUN chmod +x /dumb-init

--- a/java-8/README.md
+++ b/java-8/README.md
@@ -37,5 +37,6 @@ and build using `docker build --build-arg JAR_FILE=my-awesome.jar`
 * Exposing port `8080`
 * `-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap`
 * Main JAR file `/app/app.jar`
+* `app.jar` not running as PID 1
 
 Custom runtime options may be specified using the environment variable `JAVA_OPTS`.


### PR DESCRIPTION
 Added `dumb-init` as entrypoint to the `java-8` image.
Changed base from `openjdk:8-jre-alpine` to `openjdk:8-jdk-alpine` to have JVM utils included, to be able to make heapdumps etc.

I'll give `java-9` the same treatment later today.
