### PR TITLE
Oppdatert navikt/java:8 til openjdk 8u181-b13 med debian

### DIFF
--- a/java-8/Dockerfile
+++ b/java-8/Dockerfile
@@ -1,9 +1,7 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8u181-jdk
 
 RUN wget -O /dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64
 RUN chmod +x /dumb-init
-
-RUN apk add --no-cache curl
 
 ENV LC_ALL="no_NB.UTF-8"
 ENV LANG="no_NB.UTF-8"


### PR DESCRIPTION
Har oppdatert JDK 8 imaget til siste "offisielle" openjdk bygget fra docker community.

`8-jdk-alpine` har ikke vært oppdatert på en stund. Det er basert på alpine 3.8 og det siste openjdk bygget for det er 8u171-b11. Teamet er mindre enn de som bygger ting for Debian, så for å ikke henge langt etter med JDK 8 oppdateringer så valgte jeg heller å bytte underliggende OS.

curl er fjernet fra vår Dockerfile men det skal være inkludert i et annet layer.

Ellers skal ting fungere som før.