### PR TITLE
Fikset feil i oppsett av locale i navikt/java:8

### DIFF
--- a/java-8/Dockerfile
+++ b/java-8/Dockerfile
@@ -3,8 +3,10 @@ FROM openjdk:8u181-jdk
 RUN wget -O /dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64
 RUN chmod +x /dumb-init
 
-ENV LC_ALL="no_NB.UTF-8"
-ENV LANG="no_NB.UTF-8"
+RUN apt-get update && apt-get install -y --no-install-recommends locales
+RUN sed -i -e 's/# nb_NO.UTF-8 UTF-8/nb_NO.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+ENV LC_ALL="nb_NO.UTF-8"
+ENV LANG="nb_NO.UTF-8"
 ENV TZ="Europe/Oslo"
 
 # Please see https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits


### PR DESCRIPTION
Det var tydeligvis en forskjell mellom locale oppsett i Alpine og Debian. 

Denne PR fikser slik at java ser default charset som `UTF-8` og locale som `nb_NO`.
