### PR TITLE
Support gradle install dist

### DIFF
--- a/java-10/Dockerfile
+++ b/java-10/Dockerfile
@@ -9,7 +9,7 @@ ENV LANG="no_NB.UTF-8"
 ENV TZ="Europe/Oslo"
 
 # Please see https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
-ENV DEFAULT_JAVA_OPTS="-XX:+UnlockExperimentalVMOptions"
+ENV DEFAULT_JVM_OPTS="-XX:+UnlockExperimentalVMOptions"
 
 COPY ./run-java.sh /
 

--- a/java-10/README.md
+++ b/java-10/README.md
@@ -33,6 +33,18 @@ COPY --from=0 /app/app.jar .
 
 and build using `docker build --build-arg JAR_FILE=my-awesome.jar`
 
+### Using gradle?
+
+You can use `gradle installDist` by making sure the startup script is
+copied into the docker container as `/app/bin/app`. Here's an example:
+
+```
+FROM navikt/java:10
+
+COPY build/install/myapp/bin/myapp bin/app
+COPY build/install/myapp/lib ./lib/
+```
+
 ### Defaults
 * Exposing port `8080`
 * `-XX:+UnlockExperimentalVMOptions`

--- a/java-10/run-java.sh
+++ b/java-10/run-java.sh
@@ -14,4 +14,9 @@ fi
 
 set -x
 
-exec java ${DEFAULT_JAVA_OPTS} ${JAVA_OPTS} -jar app.jar ${RUNTIME_OPTS} $@
+if test -f ./bin/app;
+then
+	./bin/app $@
+else
+	exec java ${DEFAULT_JVM_OPTS} ${JAVA_OPTS} -jar app.jar ${RUNTIME_OPTS} $@
+fi

--- a/java-8/Dockerfile
+++ b/java-8/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG="nb_NO.UTF-8"
 ENV TZ="Europe/Oslo"
 
 # Please see https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
-ENV DEFAULT_JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+ENV DEFAULT_JVM_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
 
 COPY ./run-java.sh /
 

--- a/java-8/README.md
+++ b/java-8/README.md
@@ -33,6 +33,18 @@ COPY --from=0 /app/app.jar .
 
 and build using `docker build --build-arg JAR_FILE=my-awesome.jar`
 
+### Using gradle?
+
+You can use `gradle installDist` by making sure the startup script is
+copied into the docker container as `/app/bin/app`. Here's an example:
+
+```
+FROM navikt/java:8
+
+COPY build/install/myapp/bin/myapp bin/app
+COPY build/install/myapp/lib ./lib/
+```
+
 ### Defaults
 * Exposing port `8080`
 * `-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap`
@@ -45,6 +57,11 @@ Custom runtime options may be specified using the environment variable `JAVA_OPT
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
+## 2018-09-xx
+
+### Added
+- Support for `gradle installDist` files
 
 ## 2018-08-30
 ### Fixed

--- a/java-8/run-java.sh
+++ b/java-8/run-java.sh
@@ -14,4 +14,10 @@ fi
 
 set -x
 
-exec java ${DEFAULT_JAVA_OPTS} ${JAVA_OPTS} -jar app.jar ${RUNTIME_OPTS} $@
+if test -f ./bin/app;
+then
+	./bin/app $@
+else
+	exec java ${DEFAULT_JVM_OPTS} ${JAVA_OPTS} -jar app.jar ${RUNTIME_OPTS} $@
+fi
+

--- a/java-9/Dockerfile
+++ b/java-9/Dockerfile
@@ -9,7 +9,7 @@ ENV LANG="no_NB.UTF-8"
 ENV TZ="Europe/Oslo"
 
 # Please see https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
-ENV DEFAULT_JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+ENV DEFAULT_JVM_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
 
 COPY ./run-java.sh /
 

--- a/java-9/run-java.sh
+++ b/java-9/run-java.sh
@@ -14,4 +14,9 @@ fi
 
 set -x
 
-exec java ${DEFAULT_JAVA_OPTS} ${JAVA_OPTS} -jar app.jar ${RUNTIME_OPTS} $@
+if test -f ./bin/app;
+then
+	./bin/app $@
+else
+	exec java ${DEFAULT_JVM_OPTS} ${JAVA_OPTS} -jar app.jar ${RUNTIME_OPTS} $@
+fi


### PR DESCRIPTION
The `gradle installDist` command creates a shell script which starts the Java application.
By using a Dockerfile similar to this:
```
FROM navikt/java:8

COPY build/install/myapp/bin/myapp bin/app
COPY build/install/myapp/lib ./lib/
```
... we can support running the apps using that script as well (that still works with the environment variables we use in our docker image).