### PR TITLE
Fix issue with DEFAULT_JVM_OPTS for Gradle dists

### DIFF
--- a/java-10/run-java.sh
+++ b/java-10/run-java.sh
@@ -19,6 +19,10 @@ set -x
 
 if test -f ./bin/app;
 then
+    # Gradle application plugin overwrites DEFAULT_JVM_OPTS
+    set +x
+    JAVA_OPTS="${JAVA_OPTS} ${DEFAULT_JVM_OPTS}"
+    set -x
     ./bin/app $@
 elif test -d "/app/WEB-INF";
 then

--- a/java-8/run-java.sh
+++ b/java-8/run-java.sh
@@ -19,6 +19,10 @@ set -x
 
 if test -f ./bin/app;
 then
+    # Gradle application plugin overwrites DEFAULT_JVM_OPTS
+    set +x
+    JAVA_OPTS="${JAVA_OPTS} ${DEFAULT_JVM_OPTS}"
+    set -x
     ./bin/app $@
 elif test -d "/app/WEB-INF";
 then

--- a/java-9/run-java.sh
+++ b/java-9/run-java.sh
@@ -16,6 +16,10 @@ set -x
 
 if test -f ./bin/app;
 then
+    # Gradle application plugin overwrites DEFAULT_JVM_OPTS
+    set +x
+    JAVA_OPTS="${JAVA_OPTS} ${DEFAULT_JVM_OPTS}"
+    set -x
 	./bin/app $@
 else
 	exec java ${DEFAULT_JVM_OPTS} ${JAVA_OPTS} -jar app.jar ${RUNTIME_OPTS} $@


### PR DESCRIPTION
Gradle's Application plugin generates shell scripts which overwrites the DEFAULT_JVM_OPTS set in the Dockerfile.

This commit ensures that these options are included.