### PR TITLE
Added support for startup scripts

### DIFF
--- a/java-10/Dockerfile
+++ b/java-10/Dockerfile
@@ -15,11 +15,13 @@ ENV DEFAULT_JVM_OPTS="-XX:+UnlockExperimentalVMOptions"
 ENV MAIN_CLASS="Main"
 ENV CLASSPATH="/app/WEB-INF/classes:/app/WEB-INF/lib/*"
 
-COPY ./run-java.sh /
+COPY init-scripts /init-scripts
+COPY entrypoint.sh /
+COPY run-java.sh /
 
 WORKDIR /app
 
 EXPOSE 8080
 
 ENTRYPOINT ["/dumb-init"]
-CMD ["/run-java.sh"]
+CMD ["/entrypoint.sh"]

--- a/java-10/README.md
+++ b/java-10/README.md
@@ -4,11 +4,12 @@ NAIS Java 10 baseimage
 Basic Usage
 ---------------------
 
-We support three ways of running your app:
+We support three (four) ways of running your app:
 
 1. A fat jar called `app.jar`
 2. An exploded war
 3. Startup script generated using Maven Assembly og Gradle's `installDist`
+4. Custom run script
 
 Create a `Dockerfile` containing:
 
@@ -42,10 +43,51 @@ Supply the name of your main class as an environment variable called
 
 Custom runtime options may be specified using the environment variable `JAVA_OPTS`.
 
+### Start up scripts
+
+You can add custom behavior to your container by copying `.sh` files
+to the `/init-scripts` dir. The files are sourced which means that
+you can export environment variables or extend the existing ones like `JAVA_OPTS`.
+
+For example adding support for AppDynamics:
+
+```bash
+# copy this into your container as
+# /init-scripts/10-appdynamics.sh (example)
+
+if test -r "/opt/appdynamics/agent.jar";
+then
+    JAVA_OPTS="${JAVA_OPTS} -javaagent:/opt/appdynamics/agent.jar"
+    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.applicationName=my_app"
+    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.nodeName=prod-${HOSTNAME}"
+    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.tierName=prod-my_app"
+fi
+```
+
+### Run script
+
+As mentioned above the baseimage defaults to three ways of running
+a java app. If none of these suits you, you can create a custom run-script
+at `/run-java.sh`. Be sure to include the different environment variables
+`JAVA_OPTS`, `DEFAULT_JVM_OPTS` and `RUNTIME_OPTS` to get all the goodies 
+that the baseimage sets up for you.
+
+```bash
+# copy into the container as /run-java.sh
+exec java ${DEFAULT_JVM_OPTS} ${JAVA_OPTS} -jar app.jar ${RUNTIME_OPTS} $@
+```
+
+We highly recommend that you write your app so that you don't need this feature.
+
 # Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
+## 2018-10-20
+
+### Added
+- Support for start up scripts
 
 ## 2018-10-15
 ### Fixed

--- a/java-10/entrypoint.sh
+++ b/java-10/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+if test -d /init-scripts;
+then
+    for FILE in /init-scripts/*.sh
+    do
+        echo Sourcing $FILE
+        . $FILE
+    done
+else
+    echo "/init-scripts does not exist, skipping startup scripts"
+fi
+
+exec run-java.sh

--- a/java-10/entrypoint.sh
+++ b/java-10/entrypoint.sh
@@ -11,4 +11,4 @@ else
     echo "/init-scripts does not exist, skipping startup scripts"
 fi
 
-exec run-java.sh
+exec /run-java.sh

--- a/java-10/init-scripts/00-truststore.sh
+++ b/java-10/init-scripts/00-truststore.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+if test -r "${NAV_TRUSTSTORE_PATH}";
+then
+    if ! echo "${NAV_TRUSTSTORE_PASSWORD}" | keytool -list -keystore ${NAV_TRUSTSTORE_PATH} > /dev/null;
+    then
+        echo Truststore is corrupt, or bad password
+        exit 1
+    fi
+
+    JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${NAV_TRUSTSTORE_PATH}"
+    JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStorePassword=${NAV_TRUSTSTORE_PASSWORD}"
+fi
+

--- a/java-10/init-scripts/01-http-proxy.sh
+++ b/java-10/init-scripts/01-http-proxy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# inject proxy settings set by the nais platform
+JAVA_OPTS="${JAVA_OPTS} ${JAVA_PROXY_OPTIONS}"

--- a/java-10/run-java.sh
+++ b/java-10/run-java.sh
@@ -1,31 +1,14 @@
 #!/usr/bin/env sh
 
-if test -r "${NAV_TRUSTSTORE_PATH}";
-then
-    if ! echo "${NAV_TRUSTSTORE_PASSWORD}" | keytool -list -keystore ${NAV_TRUSTSTORE_PATH} > /dev/null;
-    then
-        echo Truststore is corrupt, or bad password
-        exit 1
-    fi
-
-    JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${NAV_TRUSTSTORE_PATH}"
-    JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStorePassword=${NAV_TRUSTSTORE_PASSWORD}"
-fi
-
-# inject proxy settings set by the nais platform
-JAVA_OPTS="${JAVA_OPTS} ${JAVA_PROXY_OPTIONS}"
-
-set -x
-
 if test -f ./bin/app;
 then
     # Gradle application plugin overwrites DEFAULT_JVM_OPTS
-    set +x
     JAVA_OPTS="${JAVA_OPTS} ${DEFAULT_JVM_OPTS}"
     set -x
     ./bin/app $@
 elif test -d "/app/WEB-INF";
 then
+    set -x
     exec java \
     ${DEFAULT_JVM_OPTS} \
     ${JAVA_OPTS} \
@@ -35,6 +18,7 @@ then
     ${RUNTIME_OPTS} \
     $@
 else
+    set -x
     exec java \
     ${DEFAULT_JVM_OPTS} \
     ${JAVA_OPTS} \

--- a/java-11/Dockerfile
+++ b/java-11/Dockerfile
@@ -12,11 +12,13 @@ ENV TZ="Europe/Oslo"
 ENV MAIN_CLASS="Main"
 ENV CLASSPATH="/app/WEB-INF/classes:/app/WEB-INF/lib/*"
 
-COPY ./run-java.sh /
+COPY init-scripts /init-scripts
+COPY entrypoint.sh /
+COPY run-java.sh /
 
 WORKDIR /app
 
 EXPOSE 8080
 
 ENTRYPOINT ["/dumb-init"]
-CMD ["/run-java.sh"]
+CMD ["/entrypoint.sh"]

--- a/java-11/README.md
+++ b/java-11/README.md
@@ -4,11 +4,12 @@ NAIS Java 11 baseimage
 Basic Usage
 ---------------------
 
-We support three ways of running your app:
+We support three (four) ways of running your app:
 
 1. A fat jar called `app.jar`
 2. An exploded war
 3. Startup script generated using Maven Assembly og Gradle's `installDist`
+4. Custom run script
 
 Create a `Dockerfile` containing:
 
@@ -42,10 +43,50 @@ Supply the name of your main class as an environment variable called
 
 Custom runtime options may be specified using the environment variable `JAVA_OPTS`.
 
+### Start up scripts
+
+You can add custom behavior to your container by copying `.sh` files
+to the `/init-scripts` dir. The files are sourced which means that
+you can export environment variables or extend the existing ones like `JAVA_OPTS`.
+
+For example adding support for AppDynamics:
+
+```bash
+# copy this into your container as
+# /init-scripts/10-appdynamics.sh (example)
+
+if test -r "/opt/appdynamics/agent.jar";
+then
+    JAVA_OPTS="${JAVA_OPTS} -javaagent:/opt/appdynamics/agent.jar"
+    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.applicationName=my_app"
+    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.nodeName=prod-${HOSTNAME}"
+    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.tierName=prod-my_app"
+fi
+```
+### Run script
+
+As mentioned above the baseimage defaults to three ways of running
+a java app. If none of these suits you, you can create a custom run-script
+at `/run-java.sh`. Be sure to include the different environment variables
+`JAVA_OPTS`, `DEFAULT_JVM_OPTS` and `RUNTIME_OPTS` to get all the goodies 
+that the baseimage sets up for you.
+
+```bash
+# copy into the container as /run-java.sh
+exec java ${DEFAULT_JVM_OPTS} ${JAVA_OPTS} -jar app.jar ${RUNTIME_OPTS} $@
+```
+
+We highly recommend that you write your app so that you don't need this feature.
+
 # Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
+## 2018-10-20
+
+### Added
+- Support for start up scripts
 
 ## 2018-10-15
 ### Fixed

--- a/java-11/entrypoint.sh
+++ b/java-11/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+if test -d /init-scripts;
+then
+    for FILE in /init-scripts/*.sh
+    do
+        echo Sourcing $FILE
+        . $FILE
+    done
+else
+    echo "/init-scripts does not exist, skipping startup scripts"
+fi
+
+exec run-java.sh

--- a/java-11/entrypoint.sh
+++ b/java-11/entrypoint.sh
@@ -11,4 +11,4 @@ else
     echo "/init-scripts does not exist, skipping startup scripts"
 fi
 
-exec run-java.sh
+exec /run-java.sh

--- a/java-11/init-scripts/00-truststore.sh
+++ b/java-11/init-scripts/00-truststore.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+if test -r "${NAV_TRUSTSTORE_PATH}";
+then
+    if ! echo "${NAV_TRUSTSTORE_PASSWORD}" | keytool -list -keystore ${NAV_TRUSTSTORE_PATH} > /dev/null;
+    then
+        echo Truststore is corrupt, or bad password
+        exit 1
+    fi
+
+    JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${NAV_TRUSTSTORE_PATH}"
+    JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStorePassword=${NAV_TRUSTSTORE_PASSWORD}"
+fi
+

--- a/java-11/init-scripts/01-http-proxy.sh
+++ b/java-11/init-scripts/01-http-proxy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# inject proxy settings set by the nais platform
+JAVA_OPTS="${JAVA_OPTS} ${JAVA_PROXY_OPTIONS}"

--- a/java-11/run-java.sh
+++ b/java-11/run-java.sh
@@ -1,31 +1,14 @@
 #!/usr/bin/env sh
 
-if test -r "${NAV_TRUSTSTORE_PATH}";
-then
-    if ! echo "${NAV_TRUSTSTORE_PASSWORD}" | keytool -list -keystore ${NAV_TRUSTSTORE_PATH} > /dev/null;
-    then
-        echo Truststore is corrupt, or bad password
-        exit 1
-    fi
-
-    JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${NAV_TRUSTSTORE_PATH}"
-    JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStorePassword=${NAV_TRUSTSTORE_PASSWORD}"
-fi
-
-# inject proxy settings set by the nais platform
-JAVA_OPTS="${JAVA_OPTS} ${JAVA_PROXY_OPTIONS}"
-
-set -x
-
 if test -f ./bin/app;
 then
     # Gradle application plugin overwrites DEFAULT_JVM_OPTS
-    set +x
     JAVA_OPTS="${JAVA_OPTS} ${DEFAULT_JVM_OPTS}"
     set -x
     ./bin/app $@
 elif test -d "/app/WEB-INF";
 then
+    set -x
     exec java \
     ${DEFAULT_JVM_OPTS} \
     ${JAVA_OPTS} \
@@ -35,6 +18,7 @@ then
     ${RUNTIME_OPTS} \
     $@
 else
+    set -x
     exec java \
     ${DEFAULT_JVM_OPTS} \
     ${JAVA_OPTS} \

--- a/java-8/Dockerfile
+++ b/java-8/Dockerfile
@@ -15,11 +15,13 @@ ENV DEFAULT_JVM_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimit
 ENV MAIN_CLASS="Main"
 ENV CLASSPATH="/app/WEB-INF/classes:/app/WEB-INF/lib/*"
 
-COPY ./run-java.sh /
+COPY init-scripts /init-scripts
+COPY entrypoint.sh /
+COPY run-java.sh /
 
 WORKDIR /app
 
 EXPOSE 8080
 
 ENTRYPOINT ["/dumb-init"]
-CMD ["/run-java.sh"]
+CMD ["/entrypoint.sh"]

--- a/java-8/README.md
+++ b/java-8/README.md
@@ -4,11 +4,12 @@ NAIS Java 8 baseimage
 Basic Usage
 ---------------------
 
-We support three ways of running your app:
+We support three (four) ways of running your app:
 
 1. A fat jar called `app.jar`
 2. An exploded war
 3. Startup script generated using Maven Assembly og Gradle's `installDist`
+4. Custom run script
 
 Create a `Dockerfile` containing:
 
@@ -42,10 +43,51 @@ Supply the name of your main class as an environment variable called
 
 Custom runtime options may be specified using the environment variable `JAVA_OPTS`.
 
+### Start up scripts
+
+You can add custom behavior to your container by copying `.sh` files
+to the `/init-scripts` dir. The files are sourced which means that
+you can export environment variables or extend the existing ones like `JAVA_OPTS`.
+
+For example adding support for AppDynamics:
+
+```bash
+# copy this into your container as
+# /init-scripts/10-appdynamics.sh (example)
+
+if test -r "/opt/appdynamics/agent.jar";
+then
+    JAVA_OPTS="${JAVA_OPTS} -javaagent:/opt/appdynamics/agent.jar"
+    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.applicationName=my_app"
+    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.nodeName=prod-${HOSTNAME}"
+    JAVA_OPTS="${JAVA_OPTS} -Dappdynamics.agent.tierName=prod-my_app"
+fi
+```
+
+### Run script
+
+As mentioned above the baseimage defaults to three ways of running
+a java app. If none of these suits you, you can create a custom run-script
+at `/run-java.sh`. Be sure to include the different environment variables
+`JAVA_OPTS`, `DEFAULT_JVM_OPTS` and `RUNTIME_OPTS` to get all the goodies 
+that the baseimage sets up for you.
+
+```bash
+# copy into the container as /run-java.sh
+exec java ${DEFAULT_JVM_OPTS} ${JAVA_OPTS} -jar app.jar ${RUNTIME_OPTS} $@
+```
+
+We highly recommend that you write your app so that you don't need this feature.
+
 # Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
+## 2018-10-20
+
+### Added
+- Support for start up scripts
 
 ## 2018-09-14
 

--- a/java-8/entrypoint.sh
+++ b/java-8/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+if test -d /init-scripts;
+then
+    for FILE in /init-scripts/*.sh
+    do
+        echo Sourcing $FILE
+        . $FILE
+    done
+else
+    echo "/init-scripts does not exist, skipping startup scripts"
+fi
+
+exec run-java.sh

--- a/java-8/entrypoint.sh
+++ b/java-8/entrypoint.sh
@@ -11,4 +11,4 @@ else
     echo "/init-scripts does not exist, skipping startup scripts"
 fi
 
-exec run-java.sh
+exec /run-java.sh

--- a/java-8/init-scripts/00-truststore.sh
+++ b/java-8/init-scripts/00-truststore.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+if test -r "${NAV_TRUSTSTORE_PATH}";
+then
+    if ! echo "${NAV_TRUSTSTORE_PASSWORD}" | keytool -list -keystore ${NAV_TRUSTSTORE_PATH} > /dev/null;
+    then
+        echo Truststore is corrupt, or bad password
+        exit 1
+    fi
+
+    JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${NAV_TRUSTSTORE_PATH}"
+    JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStorePassword=${NAV_TRUSTSTORE_PASSWORD}"
+fi
+

--- a/java-8/init-scripts/01-http-proxy.sh
+++ b/java-8/init-scripts/01-http-proxy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# inject proxy settings set by the nais platform
+JAVA_OPTS="${JAVA_OPTS} ${JAVA_PROXY_OPTIONS}"

--- a/java-8/run-java.sh
+++ b/java-8/run-java.sh
@@ -1,31 +1,14 @@
 #!/usr/bin/env sh
 
-if test -r "${NAV_TRUSTSTORE_PATH}";
-then
-    if ! echo "${NAV_TRUSTSTORE_PASSWORD}" | keytool -list -keystore ${NAV_TRUSTSTORE_PATH} > /dev/null;
-    then
-        echo Truststore is corrupt, or bad password
-        exit 1
-    fi
-
-    JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${NAV_TRUSTSTORE_PATH}"
-    JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStorePassword=${NAV_TRUSTSTORE_PASSWORD}"
-fi
-
-# inject proxy settings set by the nais platform
-JAVA_OPTS="${JAVA_OPTS} ${JAVA_PROXY_OPTIONS}"
-
-set -x
-
 if test -f ./bin/app;
 then
     # Gradle application plugin overwrites DEFAULT_JVM_OPTS
-    set +x
     JAVA_OPTS="${JAVA_OPTS} ${DEFAULT_JVM_OPTS}"
     set -x
     ./bin/app $@
 elif test -d "/app/WEB-INF";
 then
+    set -x
     exec java \
     ${DEFAULT_JVM_OPTS} \
     ${JAVA_OPTS} \
@@ -35,6 +18,7 @@ then
     ${RUNTIME_OPTS} \
     $@
 else
+    set -x
     exec java \
     ${DEFAULT_JVM_OPTS} \
     ${JAVA_OPTS} \


### PR DESCRIPTION
After observing how different teams are using the baseimage, I've noticed that some teams are:
- running their app different from the three ways the baseimage supports
- depending on custom startup-logic, e.g. configuration of appdynamics

This PR tries to fix both issues in a general way by adding support for custom startup-scripts placed under `/init-scripts`. 

`run-java.sh` script is simplified so that teams that needs a super-custom way of running their app (and therefore overwriting `run-java.sh` with their own implementation), still get the other functionality provided by the baseimage (setting of truststore, proxy and so on).